### PR TITLE
help the build script find the appropriate SWIG

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,10 +27,11 @@ cmake -G "%CMAKE_GENERATOR%" ^
     -D "PYTHON_EXECUTABLE:FILEPATH=%PYTHON%" ^
     -D "PYTHON_INCLUDE_DIR:PATH=%PREFIX%/include" ^
     -D "PYTHON_LIBRARY:FILEPATH=%PREFIX%/libs/python%MY_PY_VER%.lib" ^
+    -D "SWIG_EXECUTABLE:FILEPATH=%PREFIX%/bin/swig" ^
     "%SRC_DIR%/SuperBuild"
 
 if errorlevel 1 exit 1
-    
+
 REM Build step
 cmake --build  . --config Release
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,6 +40,7 @@ cmake \
     -D "PYTHON_EXECUTABLE:FILEPATH=${PYTHON}" \
     -D "PYTHON_INCLUDE_DIR:PATH=$PREFIX/include/python${MY_PY_VER}" \
     -D "PYTHON_LIBRARY:FILEPATH=$PREFIX/lib/libpython${MY_PY_VER}.${SO_EXT}" \
+    -D "SWIG_EXECUTABLE:FILEPATH=${PREFIX}/bin/swig" \
     "${SRC_DIR}/SuperBuild"
 
 make -j ${CORES}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,20 +13,20 @@ build:
 
 requirements:
   build:
-    - swig
+    - swig     >=3
     - python
     - cmake    >=2.8.11
     - libtiff  4.0.*
-    - libpng   >=1.6.21,<1.7
-    - jpeg     8*
-    - zlib     1.*
+    - libpng   >=1.6.28,<1.7
+    - jpeg     9*
+    - zlib     1.2.*
     - setuptools
   run:
     - python
     - libtiff  4.0.*
-    - libpng   >=1.6.21,<1.7
-    - jpeg     8*
-    - zlib     1.*
+    - libpng   >=1.6.28,<1.7
+    - jpeg     9*
+    - zlib     1.2.*
 
 test:
   imports:


### PR DESCRIPTION
closes gh-4

can remove the second commit if there is a reason not to update the pinned package versions.

I didn't have access to Windows to test the `bld.bat` change, but I think it should be correct.