### PR TITLE
ENH: Match package version dependancies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,20 +13,20 @@ build:
 
 requirements:
   build:
-    - swig
+    - swig     >=3
     - python
-    - cmake    >=2.8.11
+    - cmake    >=3.0*
     - libtiff  4.0.*
     - libpng   >=1.6.21,<1.7
-    - jpeg     8*
-    - zlib     1.*
+    - jpeg     >=8
+    - zlib     >=1.2.*
     - setuptools
   run:
     - python
     - libtiff  4.0.*
     - libpng   >=1.6.21,<1.7
-    - jpeg     8*
-    - zlib     1.*
+    - jpeg     >=8*
+    - zlib     >=1.2.*
 
 test:
   imports:


### PR DESCRIPTION
The package dependancies needed to be updated to match the standard
anaconda 3.6 release rather than the bleeding edge conda-forge versions.

cmake >=3 was also specified as this appears to be a requirement