### PR TITLE
Updating build requirements to current versions in conda proper

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,20 +13,20 @@ build:
 
 requirements:
   build:
-    - swig
+    - swig    >=3
     - python
-    - cmake    >=2.8.11
+    - cmake    >=3.3
     - libtiff  4.0.*
-    - libpng   >=1.6.21,<1.7
-    - jpeg     8*
-    - zlib     1.*
+    - libpng   >=1.6.27,<1.7
+    - jpeg     9*
+    - zlib     1.2.*
     - setuptools
   run:
     - python
     - libtiff  4.0.*
-    - libpng   >=1.6.21,<1.7
-    - jpeg     8*
-    - zlib     1.*
+    - libpng   >=1.6.27,<1.7
+    - jpeg     9*
+    - zlib     1.2.*
 
 test:
   imports:


### PR DESCRIPTION
Adding requirement for SWIG version >=3, along with a recent version
of cmake.

Co-Authored: Gregory R. Lee <gregory.lee@cchmc.org>
Co-Authored: Hans Johnson <hans-johnson@uiowa.edu>