### PR TITLE
Update to use pin_compatible for library version specification

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,19 +14,21 @@ build:
 requirements:
   build:
     - swig     >=3
-    - python
     - cmake    >=3.3
-    - libtiff  4.0.*
-    - libpng   >=1.6.27,<1.7
-    - jpeg     9*
-    - zlib     1.2.*
     - setuptools
+    - python
+    - libtiff
+    - libpng
+    - jpeg
+    - zlib
+
   run:
     - python
-    - libtiff  4.0.*
-    - libpng   >=1.6.27,<1.7
-    - jpeg     9*
-    - zlib     1.2.*
+    - {{ pin_compatible('libtiff', max_pin='x.x') }}
+    - {{ pin_compatible('libpng', max_pin='x.x') }}
+    - {{ pin_compatible('jpeg', max_pin='x') }}
+    - {{ pin_compatible('zlib', max_pin='x.x') }}
+
 
 test:
   imports:


### PR DESCRIPTION
Instead of having to manual specify the version of library needed at
run-time, conda-build 3 allows the selection of a dependency based on
what the package was build with.