### PR TITLE
Hard code the OSX SYSROOT path for Azure

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 jobs:
   - job: Windows
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
+    cancelTimeoutInMinutes: 200
     strategy:
       maxParallel: 2
       matrix:
@@ -114,9 +114,9 @@ jobs:
   - job: Linux
 
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
+    cancelTimeoutInMinutes: 200
     strategy:
-      maxParallel: 2
+      maxParallel: 3
       matrix:
         Python37:
           imageName: 'Ubuntu-16.04'
@@ -194,6 +194,98 @@ jobs:
             echo "LINUX32: ${LINUX32}"
           fi
           ${LINUX32} conda build --python "$VAR_PYTHON_VERSION" --output-folder channel recipe
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/channel/'
+          contents: '*/simpleitk*.tar.bz2'
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: false
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: AnacondaPackage
+
+  - job: MacOSX
+
+    timeoutInMinutes: 0
+    cancelTimeoutInMinutes: 100
+    strategy:
+      maxParallel: 1
+      matrix:
+        Python37:
+          imageName: 'macOS-10.13'
+          MACOSX_DEPLOYMENT_TARGET: '10.9'
+          var.python_version: 37
+          var.arch: x64
+        Python36:
+          imageName: 'macOS-10.13'
+          MACOSX_DEPLOYMENT_TARGET: '10.9'
+          var.python_version: 36
+          var.arch: x64
+        Python35:
+          imageName: 'macOS-10.13'
+          MACOSX_DEPLOYMENT_TARGET: '10.9'
+          var.python_version: 35
+          var.arch: x64
+        Python27:
+          imageName: 'macOS-10.13'
+          MACOSX_DEPLOYMENT_TARGET: '10.9'
+          var.python_version: 27
+          var.arch: x64
+
+    pool:
+      vmImage: $(imageName)
+
+    steps:
+      - bash: |
+          set -x
+          if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+            git checkout $(System.PullRequest.SourceCommitId)
+          fi
+        displayName: Checkout pull request HEAD
+      - bash: |
+
+          curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+          /bin/bash Miniconda3-latest-MacOSX-x86_64.sh -p ${AGENT_BUILDDIRECTORY}/miniconda3 -b
+          echo "##vso[task.prependpath]${AGENT_BUILDDIRECTORY}/miniconda3/bin"
+        displayName: "Installing Miniconda"
+      - bash: |
+          source activate
+          which conda
+          conda update --yes --name base -c defaults conda
+          conda create --yes --quiet --name bld
+          conda activate bld
+          conda install --yes --name bld conda-build
+
+
+          # see https://github.com/ContinuumIO/anaconda-issues/issues/9096
+          # https://stackoverflow.com/questions/53637414/conda-build-r-package-fails-at-c-compiler-issue-on-macos-mojave
+          $(Build.SourcesDirectory)/.azure-pipelines/support/osx_install_sdk.sh
+          cat << EOF >> ${AGENT_BUILDDIRECTORY}/conda_build_config.yml
+          CONDA_BUILD_SYSROOT:
+             - $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk
+          MACOSX_DEPLOYMENT_TARGET:
+             - ${MACOSX_DEPLOYMENT_TARGET}
+          EOF
+
+          cat << EOF > ~/.condarc
+          conda_build:
+            config_file: ${AGENT_BUILDDIRECTORY}/conda_build_config.yml
+          EOF
+          cat  ${AGENT_BUILDDIRECTORY}/conda_build_config.yml
+          cat  ~/.condarc
+
+        displayName: "Creating updated environment with conda-build..."
+      - bash: |
+
+          export PYTHONUNBUFFERED=1
+
+          source activate
+          conda activate bld
+
+          set -x
+          conda build --python "$VAR_PYTHON_VERSION" --output-folder channel recipe
+        displayName: "Building..."
       - task: CopyFiles@2
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)/channel/'

--- a/.azure-pipelines/support/osx_install_sdk.sh
+++ b/.azure-pipelines/support/osx_install_sdk.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.9}
+
+echo "Downloading ${MACOSX_DEPLOYMENT_TARGET} sdk"
+
+curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz
+
+tar -xf MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz -C "$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs"
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [ `uname` == Darwin ]; then
-    CMAKE_ARGS="-D CMAKE_OSX_DEPLOYMENT_TARGET:STRING=${MACOSX_DEPLOYMENT_TARGET}"
-fi
-
 # When building 32-bits on 64-bit system this flags is not automatically set by conda-build
 if [ $ARCH == 32 -a "${OSX_ARCH:-notosx}" == "notosx" ]; then
     export CFLAGS="${CFLAGS} -m32"


### PR DESCRIPTION
conda build on osx can only link against OSX SDK 10.10. We are hard
coding the CMake variable to use this SDK.