### PR TITLE
Enable autopublish on push master & fix workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -142,7 +142,7 @@ jobs:
     environment: 
       name: release
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.skip-build == 'false' }}
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
     needs: [build-windows, build-linux, build-mac]
 
     steps:
@@ -161,6 +161,8 @@ jobs:
       run: anaconda logout
 
   publish-no-build:
+    environment: 
+      name: release
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.skip-build == 'true' }}
 
@@ -168,7 +170,8 @@ jobs:
     - uses: dawidd6/action-download-artifact@v2
       with: 
         workflow_conclusion: success
-        workflow: windows.yml
+        workflow: build-and-release.yml
+        branch: ${{ github.ref }}
     - name: Verify files
       run: ls -LR
     - name: Sign into anaconda and upload


### PR DESCRIPTION
Enable autopublish on push to master.  Also corrects the skip build workflow to publish artifacts from the correct workflow and branch.